### PR TITLE
Add support for character speed

### DIFF
--- a/Assets/Scenes/HelloWorldCombat.unity
+++ b/Assets/Scenes/HelloWorldCombat.unity
@@ -1201,11 +1201,13 @@ MonoBehaviour:
   playerWeaponName: Great Sword
   playerWeaponDamage: 10
   playerWeaponDefense: 3
+  playerSpeed: 3
   enemyName: Troll
   enemyWeaponName: Club
   enemyHealth: 100
   enemyWeaponDamage: 10
   enemyWeaponDefense: 3
+  enemySpeed: 1
 --- !u!114 &1156787234
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Source/Game/Character.cs
+++ b/Assets/Scripts/Source/Game/Character.cs
@@ -32,7 +32,7 @@ public class Character
         }
     }
 
-    public float Speed
+    public virtual int Speed
     {
         get
         {
@@ -40,6 +40,11 @@ public class Character
         }
         private set
         {
+            if(value < 0)
+            {
+                _speed = 0;
+                return;
+            }
             _speed = value;
         }
     }
@@ -57,9 +62,9 @@ public class Character
     }
 
     int _health;
-    float _speed;
+    int _speed;
 
-    public Character(string name, int health, float speed)
+    public Character(string name, int health, int speed)
     {
         characterCombatHandler = new CharacterCombatHandler();
         this.Name = name;
@@ -68,7 +73,7 @@ public class Character
         this.Speed = speed;
     }
 
-    public Character(string name, int health, float speed, CharacterCombatHandler characterCombatHandler)
+    public Character(string name, int health, int speed, CharacterCombatHandler characterCombatHandler)
     {
         this.characterCombatHandler = characterCombatHandler;
         this.Name = name;

--- a/Assets/Scripts/Source/Game/Character.cs
+++ b/Assets/Scripts/Source/Game/Character.cs
@@ -32,6 +32,18 @@ public class Character
         }
     }
 
+    public float Speed
+    {
+        get
+        {
+            return _speed;
+        }
+        private set
+        {
+            _speed = value;
+        }
+    }
+
     public Weapon EquippedWeapon
     {
         get;
@@ -45,21 +57,24 @@ public class Character
     }
 
     int _health;
+    float _speed;
 
-    public Character(string name, int health)
+    public Character(string name, int health, float speed)
     {
         characterCombatHandler = new CharacterCombatHandler();
         this.Name = name;
         this.MaxHealth = health;
         this.Health = health;
+        this.Speed = speed;
     }
 
-    public Character(string name, int health, CharacterCombatHandler characterCombatHandler)
+    public Character(string name, int health, float speed, CharacterCombatHandler characterCombatHandler)
     {
         this.characterCombatHandler = characterCombatHandler;
         this.Name = name;
         this.MaxHealth = health;
         this.Health = health;
+        this.Speed = speed;
     }
 
     public virtual void Damage(int damage)

--- a/Assets/Scripts/Source/Game/Combat/CombatManager.cs
+++ b/Assets/Scripts/Source/Game/Combat/CombatManager.cs
@@ -3,7 +3,7 @@ using System.Collections;
 
 public class CombatManager : MonoBehaviour
 {
-    // TODO: Replace permanent solution
+    // TODO: Replace with permanent solution
     [SerializeField]
     float delayBetweenActions = 1f;
 
@@ -56,7 +56,7 @@ public class CombatManager : MonoBehaviour
 
     IEnumerator executeActions()
     {   
-        while(!turnManager.ShouldWaitForPlayerAction())
+        while(!turnManager.ShouldWaitForPlayerAction(characterManager.GetActivePlayer()))
         {
             ProcessNextAction();
             yield return new WaitForSeconds(delayBetweenActions);

--- a/Assets/Scripts/Source/Game/Combat/CombatManager.cs
+++ b/Assets/Scripts/Source/Game/Combat/CombatManager.cs
@@ -42,13 +42,17 @@ public class CombatManager : MonoBehaviour
 
     void onPlayerActionReceived()
     {
+        if(turnManager.ShouldWaitForPlayerAction(characterManager.GetActivePlayer()))
+        {
+            return;
+        }
         generateEnemyActions();
         StartCoroutine(executeActions());
     }
 
     void generateEnemyActions()
     {
-        foreach (Enemy enemy in characterManager.GetEnemies())
+        foreach(Enemy enemy in characterManager.GetEnemies())
         {
             turnManager.RegisterAction(characterManager.RequestNextAction(enemy));
         }

--- a/Assets/Scripts/Source/Game/Combat/PlaceholderCombatUI.cs
+++ b/Assets/Scripts/Source/Game/Combat/PlaceholderCombatUI.cs
@@ -1,9 +1,9 @@
-using System;
 using UnityEngine;
 using UnityEngine.UI;
 
 public class PlaceholderCombatUI : AbstractCombatUI
 {
+    int actionIndex = 1;
     [SerializeField]
     Image playerHealth, enemyHealth;
 
@@ -21,8 +21,8 @@ public class PlaceholderCombatUI : AbstractCombatUI
     {
         playerName = player.Name;
         return new CharacterCombatHandler(
-            ()=>{actionBar.text = string.Format("{0} is attacking with {1}", player.Name, player.EquippedWeapon.Name);},
-            ()=>{actionBar.text = string.Format("{0} is defending with {1}", player.Name, player.EquippedWeapon.Name);},
+            ()=>{actionBar.text = string.Format("({2}) {0} is attacking with {1}", player.Name, player.EquippedWeapon.Name, actionIndex++);},
+            ()=>{actionBar.text = string.Format("({2}) {0} is defending with {1}", player.Name, player.EquippedWeapon.Name, actionIndex++);},
             damagePlayer,
             killPlayer
         );
@@ -46,8 +46,8 @@ public class PlaceholderCombatUI : AbstractCombatUI
     {
         enemyName = enemy.Name;
         return new CharacterCombatHandler(
-            ()=>{actionBar.text = string.Format("{0} is attacking with {1}", enemy.Name, enemy.EquippedWeapon.Name);},
-            ()=>{actionBar.text = string.Format("{0} is defending with {1}", enemy.Name, enemy.EquippedWeapon.Name);},
+            ()=>{actionBar.text = string.Format("({2}) {0} is attacking with {1}", enemy.Name, enemy.EquippedWeapon.Name, actionIndex++);},
+            ()=>{actionBar.text = string.Format("({2}) {0} is defending with {1}", enemy.Name, enemy.EquippedWeapon.Name, actionIndex++);},
             damageEnemy,
             killEnemy
         );

--- a/Assets/Scripts/Source/Game/Combat/TestCombatConfig.cs
+++ b/Assets/Scripts/Source/Game/Combat/TestCombatConfig.cs
@@ -19,7 +19,7 @@ public class TestCombatConfig : AbstractCombatConfig
     int playerWeaponDefense;
 
     [SerializeField]
-    float playerSpeed = 1.0f;
+    int playerSpeed = 1;
 
     [Header("Enemy")]
     [SerializeField]
@@ -38,7 +38,7 @@ public class TestCombatConfig : AbstractCombatConfig
     int enemyWeaponDefense;
 
     [SerializeField]
-    float enemySpeed = 1.0f;
+    int enemySpeed = 1;
 
     Player player;
     Enemy enemy;

--- a/Assets/Scripts/Source/Game/Combat/TestCombatConfig.cs
+++ b/Assets/Scripts/Source/Game/Combat/TestCombatConfig.cs
@@ -18,6 +18,9 @@ public class TestCombatConfig : AbstractCombatConfig
     [SerializeField]
     int playerWeaponDefense;
 
+    [SerializeField]
+    float playerSpeed = 1.0f;
+
     [Header("Enemy")]
     [SerializeField]
     string enemyName = "Troll";
@@ -34,14 +37,17 @@ public class TestCombatConfig : AbstractCombatConfig
     [SerializeField]
     int enemyWeaponDefense;
 
+    [SerializeField]
+    float enemySpeed = 1.0f;
+
     Player player;
     Enemy enemy;
 
     void Awake()
     {
-        player = new Player(playerName, playerHealth);
+        player = new Player(playerName, playerHealth, playerSpeed);
         player.EquipWeapon(new Weapon(playerWeaponName, playerWeaponDamage, playerWeaponDefense));
-        enemy = new Enemy(enemyName, enemyHealth);
+        enemy = new Enemy(enemyName, enemyHealth, enemySpeed);
         enemy.EquipWeapon(new Weapon(enemyWeaponName, enemyWeaponDamage, enemyWeaponDefense));
     }
 

--- a/Assets/Scripts/Source/Game/Combat/TurnManager.cs
+++ b/Assets/Scripts/Source/Game/Combat/TurnManager.cs
@@ -1,29 +1,144 @@
+using System;
+using System.Linq;
 using System.Collections.Generic;
 using UnityEngine;
 
 public class TurnManager : MonoBehaviour
 {
-    Queue<CharacterAction> characterActions = new Queue<CharacterAction>();
+    List<Queue<CharacterAction>> characterActionsByRound = new List<Queue<CharacterAction>>();
+    List<Dictionary<Character, int>> turnCountByRound = new List<Dictionary<Character, int>>();
 
     // Used to test functionality
-    public void Init(Queue<CharacterAction> characterActions)
+    public void Init(List<Queue<CharacterAction>> characterActions, List<Dictionary<Character, int>> turnsInRound)
     {
-        this.characterActions = characterActions;
+        this.characterActionsByRound = characterActions;
+        this.turnCountByRound = turnsInRound;
+        addEmptyRound();
+    }
+
+    public virtual void Awake()
+    {
+        addEmptyRound();
+    }
+
+    void addEmptyRound()
+    {
+        characterActionsByRound.Add(new Queue<CharacterAction>());
+        turnCountByRound.Add(new Dictionary<Character, int>());
     }
 
     public virtual void RegisterAction(CharacterAction characterAction)
     {
-        characterActions.Enqueue(characterAction);
+        Character actor = characterAction.Actor;
+        int turnIndex = getFirstRoundForAction(actor);
+        characterActionsByRound[turnIndex].Enqueue(characterAction);
+        turnCountByRound[turnIndex][actor]++;
+    }
+
+    int getFirstRoundForAction(Character character)
+    {
+        if(character.Speed == 0)
+        {
+            throw new UnableToRegisterActionException("getFirstRoundForAction: Character has speed 0");
+        }
+
+        int roundIndex = -1;
+        int characterTurnsInRound;
+        do
+        {
+            roundIndex++;
+            if(roundIndex >= turnCountByRound.Count)
+            {
+                addEmptyRound();
+            }
+            Dictionary<Character, int> turnsInRound = turnCountByRound[roundIndex];
+            if(!turnsInRound.ContainsKey(character))
+            {
+                turnsInRound[character] = 0;
+            }
+            characterTurnsInRound = turnsInRound[character];
+        }while(characterTurnsInRound >= character.Speed);
+        return roundIndex;
     }
 
     public virtual CharacterAction GetNextAction()
     {
-        return characterActions.Dequeue();
+        cleanupQueue();
+        if(characterActionsByRound.Count == 0)
+        {
+            throw new NoCharacterActionExistsException("GetNextAction: no actions remaining in queue");
+        }
+        CharacterAction nextAction = characterActionsByRound.First().Dequeue();
+        cleanupQueue();
+        return nextAction;
     }
 
-    public virtual bool ShouldWaitForPlayerAction()
+    void cleanupQueue()
     {
-        // TODO
-        return characterActions.Count == 0;
+        while(characterActionsByRound.Count > 0 && characterActionsByRound.First().Count == 0)
+        {
+            characterActionsByRound.RemoveAt(0);
+            turnCountByRound.RemoveAt(0);
+        }
+    }
+
+    public virtual bool ShouldWaitForPlayerAction(Player player)
+    {
+        if(player.Speed == 0)
+        {
+            return false;
+        }
+        if(characterActionsByRound.Count == 0)
+        {
+            return true;
+        }
+
+        Queue<CharacterAction> roundActions = characterActionsByRound.Last();
+        Dictionary<Character, int> countsInRound = turnCountByRound.Last();
+        if(roundActions.Count == 0)
+        {
+            return true;
+        }
+        if(roundActions.Last().Actor is Enemy && 
+            countsInRound.ContainsKey(player) &&
+            countsInRound[player] < player.Speed)
+        {
+            return true;
+        }
+        return false;
+    }
+}
+
+public class NoCharacterActionExistsException : Exception
+{
+    public NoCharacterActionExistsException()
+    {
+    }
+
+    public NoCharacterActionExistsException(string message)
+        : base(message)
+    {
+    }
+
+    public NoCharacterActionExistsException(string message, Exception inner)
+        : base(message, inner)
+    {
+    }
+}
+
+public class UnableToRegisterActionException : Exception
+{
+    public UnableToRegisterActionException()
+    {
+    }
+
+    public UnableToRegisterActionException(string message)
+        : base(message)
+    {
+    }
+
+    public UnableToRegisterActionException(string message, Exception inner)
+        : base(message, inner)
+    {
     }
 }

--- a/Assets/Scripts/Source/Game/Combat/TurnManager.cs
+++ b/Assets/Scripts/Source/Game/Combat/TurnManager.cs
@@ -99,13 +99,17 @@ public class TurnManager : MonoBehaviour
         {
             return true;
         }
-        if(roundActions.Last().Actor is Enemy && 
-            countsInRound.ContainsKey(player) &&
-            countsInRound[player] < player.Speed)
+        // CASE: Player hasn't taken a turn yet
+        if(!countsInRound.ContainsKey(player))
         {
             return true;
         }
-        return false;
+        // CASE: Player has used all their turns for the round
+        if(countsInRound[player] >= player.Speed)
+        {
+            return false;
+        }
+        return true;
     }
 }
 

--- a/Assets/Scripts/Source/Game/Enemy.cs
+++ b/Assets/Scripts/Source/Game/Enemy.cs
@@ -1,6 +1,6 @@
 public class Enemy : Character 
 {
-    public Enemy(string name, int health, float speed) : base(name, health, speed)
+    public Enemy(string name, int health, int speed) : base(name, health, speed)
     {
 
     }

--- a/Assets/Scripts/Source/Game/Enemy.cs
+++ b/Assets/Scripts/Source/Game/Enemy.cs
@@ -1,6 +1,6 @@
 public class Enemy : Character 
 {
-    public Enemy(string name, int health) : base(name, health)
+    public Enemy(string name, int health, float speed) : base(name, health, speed)
     {
 
     }

--- a/Assets/Scripts/Source/Game/Player.cs
+++ b/Assets/Scripts/Source/Game/Player.cs
@@ -1,6 +1,6 @@
 public class Player : Character
 {
-    public Player(string name, int health, float speed) : base(name, health, speed)
+    public Player(string name, int health, int speed) : base(name, health, speed)
     {
         
     }

--- a/Assets/Scripts/Source/Game/Player.cs
+++ b/Assets/Scripts/Source/Game/Player.cs
@@ -1,6 +1,6 @@
 public class Player : Character
 {
-    public Player(string name, int health) : base(name, health)
+    public Player(string name, int health, float speed) : base(name, health, speed)
     {
         
     }

--- a/Assets/Scripts/Source/Util/RandomGenerator.cs
+++ b/Assets/Scripts/Source/Util/RandomGenerator.cs
@@ -1,4 +1,4 @@
-﻿using UnityEngine;
+using UnityEngine;
 
 public class RandomGenerator 
 {

--- a/Assets/Scripts/Test/Editor/Game/CharacterManagerTest.cs
+++ b/Assets/Scripts/Test/Editor/Game/CharacterManagerTest.cs
@@ -23,8 +23,8 @@ public class CharacterManagerTest
     [Test]
     public void TestRequestNextAction()
     {
-        Player mockPlayer = new Mock<Player>("name", 100, 1.0f).Object;
-        Enemy mockEnemy = new Mock<Enemy>("name", 100, 1.0f).Object;
+        Player mockPlayer = new Mock<Player>("name", 100, 1).Object;
+        Enemy mockEnemy = new Mock<Enemy>("name", 100, 1).Object;
         CharacterAction mockCharacterAction = new Mock<CharacterAction>(mockEnemy, null, null).Object;
         mockEnemyActionManager.Setup(manager => manager.RequestNextAction(It.IsAny<Enemy>(), It.IsAny<Player>())).Returns(mockCharacterAction);
         characterManager.RegisterCharacter(mockPlayer);
@@ -38,7 +38,7 @@ public class CharacterManagerTest
     [Test]
     public void TestRegisterCharacter_Player()
     {
-        Player mockPlayer = new Mock<Player>("name", 100, 1.0f).Object;
+        Player mockPlayer = new Mock<Player>("name", 100, 1).Object;
 
         characterManager.RegisterCharacter(mockPlayer);
 
@@ -48,7 +48,7 @@ public class CharacterManagerTest
     [Test]
     public void TestRegisterCharacter_Enemy()
     {
-        Enemy mockEnemy = new Mock<Enemy>("name", 100, 1.0f).Object;
+        Enemy mockEnemy = new Mock<Enemy>("name", 100, 1).Object;
 
         characterManager.RegisterCharacter(mockEnemy);
 
@@ -69,7 +69,7 @@ public class CharacterManagerTest
     public void TestProcessAction_Defend()
     {
         Mock<Defend> mockDefend = new Mock<Defend>(null, 5, null, null);
-        Mock<Character> mockActor = new Mock<Character>("name", 100, 1.0f);
+        Mock<Character> mockActor = new Mock<Character>("name", 100, 1);
         mockDefend.Setup(defend => defend.Actor).Returns(mockActor.Object);
         mockActor.Setup(actor => actor.SetActiveAction(It.IsAny<CharacterAction>()));
 

--- a/Assets/Scripts/Test/Editor/Game/CharacterManagerTest.cs
+++ b/Assets/Scripts/Test/Editor/Game/CharacterManagerTest.cs
@@ -23,8 +23,8 @@ public class CharacterManagerTest
     [Test]
     public void TestRequestNextAction()
     {
-        Player mockPlayer = new Mock<Player>("name", 100).Object;
-        Enemy mockEnemy = new Mock<Enemy>("name", 100).Object;
+        Player mockPlayer = new Mock<Player>("name", 100, 1.0f).Object;
+        Enemy mockEnemy = new Mock<Enemy>("name", 100, 1.0f).Object;
         CharacterAction mockCharacterAction = new Mock<CharacterAction>(mockEnemy, null, null).Object;
         mockEnemyActionManager.Setup(manager => manager.RequestNextAction(It.IsAny<Enemy>(), It.IsAny<Player>())).Returns(mockCharacterAction);
         characterManager.RegisterCharacter(mockPlayer);
@@ -38,7 +38,7 @@ public class CharacterManagerTest
     [Test]
     public void TestRegisterCharacter_Player()
     {
-        Player mockPlayer = new Mock<Player>("name", 100).Object;
+        Player mockPlayer = new Mock<Player>("name", 100, 1.0f).Object;
 
         characterManager.RegisterCharacter(mockPlayer);
 
@@ -48,7 +48,7 @@ public class CharacterManagerTest
     [Test]
     public void TestRegisterCharacter_Enemy()
     {
-        Enemy mockEnemy = new Mock<Enemy>("name", 100).Object;
+        Enemy mockEnemy = new Mock<Enemy>("name", 100, 1.0f).Object;
 
         characterManager.RegisterCharacter(mockEnemy);
 
@@ -69,7 +69,7 @@ public class CharacterManagerTest
     public void TestProcessAction_Defend()
     {
         Mock<Defend> mockDefend = new Mock<Defend>(null, 5, null, null);
-        Mock<Character> mockActor = new Mock<Character>("name", 100);
+        Mock<Character> mockActor = new Mock<Character>("name", 100, 1.0f);
         mockDefend.Setup(defend => defend.Actor).Returns(mockActor.Object);
         mockActor.Setup(actor => actor.SetActiveAction(It.IsAny<CharacterAction>()));
 

--- a/Assets/Scripts/Test/Editor/Game/CharacterTest.cs
+++ b/Assets/Scripts/Test/Editor/Game/CharacterTest.cs
@@ -18,11 +18,13 @@ public class CharacterTest
     {
         string testName = "test";
         int testHealth = 100;
-        character = new Character(testName, testHealth);
+        float testSpeed = 1.0f;
+        character = new Character(testName, testHealth, testSpeed);
 
         Assert.AreEqual(testName, character.Name);
         Assert.AreEqual(testHealth, character.Health);
         Assert.AreEqual(testHealth, character.MaxHealth);
+        Assert.AreEqual(testSpeed, character.Speed);
     }
 
     [Test]
@@ -60,7 +62,7 @@ public class CharacterTest
     [Test]
     public void TestAttack()
     {
-        Character mockTarget = new Mock<Character>("name", 100).Object;
+        Character mockTarget = new Mock<Character>("name", 100, 1.0f).Object;
         Mock<Weapon> mockWeapon = new Mock<Weapon>("name", 0, 0);
         int weaponDamage = 5;
         mockWeapon.Setup(weapon => weapon.Damage).Returns(weaponDamage);
@@ -78,7 +80,7 @@ public class CharacterTest
     [Test]
     public void TestDefend()
     {
-        Character mockTarget = new Mock<Character>("name", 100).Object;
+        Character mockTarget = new Mock<Character>("name", 100, 1.0f).Object;
         Mock<Weapon> mockWeapon = new Mock<Weapon>("name", 0, 0);
         int weaponDefense = 5;
         mockWeapon.Setup(weapon => weapon.Defense).Returns(weaponDefense);
@@ -119,10 +121,11 @@ public class CharacterTest
     {
         string testName = "test";
         int testHealth = 100;
+        float testSpeed = 1.0f;
         mockCombatHandler = new Mock<CharacterCombatHandler>();
         mockCombatHandler.Setup(handler => handler.Subscribe(It.IsAny<CharacterCombatHandler>()));
         mockCombatHandler.Setup(handler => handler.OnAttack());
         mockCombatHandler.Setup(handler => handler.OnDefend());
-        return new Character(testName, testHealth, mockCombatHandler.Object);
+        return new Character(testName, testHealth, testSpeed, mockCombatHandler.Object);
     }
 }

--- a/Assets/Scripts/Test/Editor/Game/CharacterTest.cs
+++ b/Assets/Scripts/Test/Editor/Game/CharacterTest.cs
@@ -18,13 +18,27 @@ public class CharacterTest
     {
         string testName = "test";
         int testHealth = 100;
-        float testSpeed = 1.0f;
+        int testSpeed = 1;
         character = new Character(testName, testHealth, testSpeed);
 
         Assert.AreEqual(testName, character.Name);
         Assert.AreEqual(testHealth, character.Health);
         Assert.AreEqual(testHealth, character.MaxHealth);
         Assert.AreEqual(testSpeed, character.Speed);
+    }
+
+    [Test]
+    public void TestInitCharacter_SpeedLessThanZero()
+    {
+        string testName = "test";
+        int testHealth = 100;
+        int testSpeed = -1;
+        character = new Character(testName, testHealth, testSpeed);
+
+        Assert.AreEqual(testName, character.Name);
+        Assert.AreEqual(testHealth, character.Health);
+        Assert.AreEqual(testHealth, character.MaxHealth);
+        Assert.AreEqual(0, character.Speed);
     }
 
     [Test]
@@ -62,7 +76,7 @@ public class CharacterTest
     [Test]
     public void TestAttack()
     {
-        Character mockTarget = new Mock<Character>("name", 100, 1.0f).Object;
+        Character mockTarget = new Mock<Character>("name", 100, 1).Object;
         Mock<Weapon> mockWeapon = new Mock<Weapon>("name", 0, 0);
         int weaponDamage = 5;
         mockWeapon.Setup(weapon => weapon.Damage).Returns(weaponDamage);
@@ -80,7 +94,7 @@ public class CharacterTest
     [Test]
     public void TestDefend()
     {
-        Character mockTarget = new Mock<Character>("name", 100, 1.0f).Object;
+        Character mockTarget = new Mock<Character>("name", 100, 1).Object;
         Mock<Weapon> mockWeapon = new Mock<Weapon>("name", 0, 0);
         int weaponDefense = 5;
         mockWeapon.Setup(weapon => weapon.Defense).Returns(weaponDefense);
@@ -121,7 +135,7 @@ public class CharacterTest
     {
         string testName = "test";
         int testHealth = 100;
-        float testSpeed = 1.0f;
+        int testSpeed = 1;
         mockCombatHandler = new Mock<CharacterCombatHandler>();
         mockCombatHandler.Setup(handler => handler.Subscribe(It.IsAny<CharacterCombatHandler>()));
         mockCombatHandler.Setup(handler => handler.OnAttack());

--- a/Assets/Scripts/Test/Editor/Game/Combat/CharacterActionTest.cs
+++ b/Assets/Scripts/Test/Editor/Game/Combat/CharacterActionTest.cs
@@ -7,8 +7,8 @@ public class CharacterActionTest
     [Test]
     public void TestInit()
     {
-        Character mockActor = new Mock<Character>("name", 100).Object;
-        Character mockTarget = new Mock<Character>("name", 100).Object;
+        Character mockActor = new Mock<Character>("name", 100, 1.0f).Object;
+        Character mockTarget = new Mock<Character>("name", 100, 1.0f).Object;
 
         CharacterAction characterAction = new CharacterAction(mockActor, null, mockTarget);
 
@@ -24,8 +24,8 @@ public class CharacterActionTest
         {
             actionRun = true;
         };
-        Character mockActor = new Mock<Character>("name", 100).Object;
-        Character mockTarget = new Mock<Character>("name", 100).Object;
+        Character mockActor = new Mock<Character>("name", 100, 1.0f).Object;
+        Character mockTarget = new Mock<Character>("name", 100, 1.0f).Object;
         CharacterAction characterAction = new CharacterAction(mockActor, testAction, mockTarget);
 
         characterAction.Use();

--- a/Assets/Scripts/Test/Editor/Game/Combat/CharacterActionTest.cs
+++ b/Assets/Scripts/Test/Editor/Game/Combat/CharacterActionTest.cs
@@ -7,8 +7,8 @@ public class CharacterActionTest
     [Test]
     public void TestInit()
     {
-        Character mockActor = new Mock<Character>("name", 100, 1.0f).Object;
-        Character mockTarget = new Mock<Character>("name", 100, 1.0f).Object;
+        Character mockActor = new Mock<Character>("name", 100, 1).Object;
+        Character mockTarget = new Mock<Character>("name", 100, 1).Object;
 
         CharacterAction characterAction = new CharacterAction(mockActor, null, mockTarget);
 
@@ -24,8 +24,8 @@ public class CharacterActionTest
         {
             actionRun = true;
         };
-        Character mockActor = new Mock<Character>("name", 100, 1.0f).Object;
-        Character mockTarget = new Mock<Character>("name", 100, 1.0f).Object;
+        Character mockActor = new Mock<Character>("name", 100, 1).Object;
+        Character mockTarget = new Mock<Character>("name", 100, 1).Object;
         CharacterAction characterAction = new CharacterAction(mockActor, testAction, mockTarget);
 
         characterAction.Use();

--- a/Assets/Scripts/Test/Editor/Game/Combat/CharacterCombatHandlerTest.cs
+++ b/Assets/Scripts/Test/Editor/Game/Combat/CharacterCombatHandlerTest.cs
@@ -1,7 +1,6 @@
 using System;
 using Eppy;
 using NUnit.Framework;
-using Moq;
 
 public class CharacterCombatHandlerTest
 {

--- a/Assets/Scripts/Test/Editor/Game/Combat/CombatInitializerTest.cs
+++ b/Assets/Scripts/Test/Editor/Game/Combat/CombatInitializerTest.cs
@@ -37,8 +37,8 @@ public class CombatInitializerTest
     [Test]
     public void TestStart()
     {
-        Mock<Player> mockPlayer = new Mock<Player>("name", 100, 1.0f);
-        Mock<Enemy> mockEnemy = new Mock<Enemy>("name", 100, 1.0f);
+        Mock<Player> mockPlayer = new Mock<Player>("name", 100, 1);
+        Mock<Enemy> mockEnemy = new Mock<Enemy>("name", 100, 1);
         Mock <CharacterCombatHandler> mockPlayerCombatHandler = new Mock<CharacterCombatHandler>();
         Mock<CharacterCombatHandler> mockEnemyCombatHandler = new Mock<CharacterCombatHandler>();
         mockCombatConfig.Setup(combatConfig => combatConfig.GetPlayer()).Returns(mockPlayer.Object);

--- a/Assets/Scripts/Test/Editor/Game/Combat/CombatInitializerTest.cs
+++ b/Assets/Scripts/Test/Editor/Game/Combat/CombatInitializerTest.cs
@@ -37,8 +37,8 @@ public class CombatInitializerTest
     [Test]
     public void TestStart()
     {
-        Mock<Player> mockPlayer = new Mock<Player>("name", 100);
-        Mock<Enemy> mockEnemy = new Mock<Enemy>("name", 100);
+        Mock<Player> mockPlayer = new Mock<Player>("name", 100, 1.0f);
+        Mock<Enemy> mockEnemy = new Mock<Enemy>("name", 100, 1.0f);
         Mock <CharacterCombatHandler> mockPlayerCombatHandler = new Mock<CharacterCombatHandler>();
         Mock<CharacterCombatHandler> mockEnemyCombatHandler = new Mock<CharacterCombatHandler>();
         mockCombatConfig.Setup(combatConfig => combatConfig.GetPlayer()).Returns(mockPlayer.Object);

--- a/Assets/Scripts/Test/Editor/Game/Combat/CombatManagerTest.cs
+++ b/Assets/Scripts/Test/Editor/Game/Combat/CombatManagerTest.cs
@@ -28,8 +28,8 @@ public class CombatManagerTest
         mockCharacterManager = new Mock<CharacterManager>();
         mockTurnManager = new Mock<TurnManager>();
         mockGameFlowManager = new Mock<GameFlowManager>();
-        mockPlayer = new Mock<Player>("name", 100, 1.0f);
-        mockEnemy = new Mock<Enemy>("name", 100, 1.0f);
+        mockPlayer = new Mock<Player>("name", 100, 1);
+        mockEnemy = new Mock<Enemy>("name", 100, 1);
         mockEnemyAction = new Mock<CharacterAction>(mockEnemy.Object, null, null);
         mockPlayerAttack = new Mock<Attack>(null, 5, null, null);
         mockPlayerDefend = new Mock<Defend>(null, 5, null, null);
@@ -37,7 +37,7 @@ public class CombatManagerTest
         mockCharacterManager.Setup(characterManager => characterManager.GetEnemies()).Returns(new Enemy[] { mockEnemy.Object });
         mockCharacterManager.Setup(characterManager => characterManager.RequestNextAction(It.IsAny<Enemy>())).Returns(mockEnemyAction.Object);
         mockTurnManager.Setup(turnManager => turnManager.RegisterAction(It.IsAny<CharacterAction>())).Callback<CharacterAction>((action) => { testActionQueue.Enqueue(action); });
-        mockTurnManager.Setup(turnManager => turnManager.ShouldWaitForPlayerAction()).Returns(() => numberEnemyTurnsTaken >= testNumberEnemyTurns);
+        mockTurnManager.Setup(turnManager => turnManager.ShouldWaitForPlayerAction(It.IsAny<Player>())).Returns(() => numberEnemyTurnsTaken >= testNumberEnemyTurns);
         mockTurnManager.Setup(turnManager => turnManager.GetNextAction()).Returns(() => testActionQueue.Count > 0 ? testActionQueue.Dequeue() : null);
         mockEnemyAction.Setup(action => action.Use()).Callback(() => { numberEnemyTurnsTaken++;});
         mockCharacterManager.Setup(characterManager => characterManager.ProcessAction(It.IsAny<CharacterAction>()));
@@ -75,7 +75,7 @@ public class CombatManagerTest
         mockPlayer.Verify(player => player.Attack(mockEnemy.Object));
         mockCharacterManager.Verify(manager => manager.RequestNextAction(mockEnemy.Object));
         mockTurnManager.Verify(turns => turns.RegisterAction(mockEnemyAction.Object));
-        mockTurnManager.Verify(turns => turns.ShouldWaitForPlayerAction());
+        mockTurnManager.Verify(turns => turns.ShouldWaitForPlayerAction(mockPlayer.Object));
         mockTurnManager.Verify(turns => turns.GetNextAction());
         mockCharacterManager.Verify(manager => manager.ProcessAction(mockPlayerAttack.Object));
         mockPlayerAttack.Verify(attack => attack.Use());
@@ -98,7 +98,7 @@ public class CombatManagerTest
         mockPlayer.Verify(player => player.Defend(mockEnemy.Object));
         mockCharacterManager.Verify(manager => manager.RequestNextAction(mockEnemy.Object));
         mockTurnManager.Verify(turns => turns.RegisterAction(mockEnemyAction.Object));
-        mockTurnManager.Verify(turns => turns.ShouldWaitForPlayerAction());
+        mockTurnManager.Verify(turns => turns.ShouldWaitForPlayerAction(mockPlayer.Object));
         mockTurnManager.Verify(turns => turns.GetNextAction());
         mockCharacterManager.Verify(manager => manager.ProcessAction(mockPlayerDefend.Object));
         mockPlayerDefend.Verify(defend => defend.Use());

--- a/Assets/Scripts/Test/Editor/Game/Combat/CombatManagerTest.cs
+++ b/Assets/Scripts/Test/Editor/Game/Combat/CombatManagerTest.cs
@@ -28,8 +28,8 @@ public class CombatManagerTest
         mockCharacterManager = new Mock<CharacterManager>();
         mockTurnManager = new Mock<TurnManager>();
         mockGameFlowManager = new Mock<GameFlowManager>();
-        mockPlayer = new Mock<Player>("name", 100);
-        mockEnemy = new Mock<Enemy>("name", 100);
+        mockPlayer = new Mock<Player>("name", 100, 1.0f);
+        mockEnemy = new Mock<Enemy>("name", 100, 1.0f);
         mockEnemyAction = new Mock<CharacterAction>(mockEnemy.Object, null, null);
         mockPlayerAttack = new Mock<Attack>(null, 5, null, null);
         mockPlayerDefend = new Mock<Defend>(null, 5, null, null);

--- a/Assets/Scripts/Test/Editor/Game/Combat/DefendTest.cs
+++ b/Assets/Scripts/Test/Editor/Game/Combat/DefendTest.cs
@@ -1,4 +1,4 @@
-﻿using NUnit.Framework;
+using NUnit.Framework;
 
 public class DefendTest
 {

--- a/Assets/Scripts/Test/Editor/Game/Combat/EnemyActionManagerTest.cs
+++ b/Assets/Scripts/Test/Editor/Game/Combat/EnemyActionManagerTest.cs
@@ -20,8 +20,8 @@ public class EnemyActionManagerTest
         enemyActionManager = gameObject.AddComponent<EnemyActionManager>();
 
         mockRandomGenerator = new Mock<RandomGenerator>();
-        mockPlayer = new Mock<Player>("name", 100);
-        mockEnemy = new Mock<Enemy>("name", 100);
+        mockPlayer = new Mock<Player>("name", 100, 1.0f);
+        mockEnemy = new Mock<Enemy>("name", 100, 1.0f);
         mockAttack = new Mock<Attack>(null, 5, null, null);
         mockDefend = new Mock<Defend>(null, 5, null, null);
 

--- a/Assets/Scripts/Test/Editor/Game/Combat/EnemyActionManagerTest.cs
+++ b/Assets/Scripts/Test/Editor/Game/Combat/EnemyActionManagerTest.cs
@@ -1,4 +1,4 @@
-﻿using UnityEngine;
+using UnityEngine;
 using NUnit.Framework;
 using Moq;
 

--- a/Assets/Scripts/Test/Editor/Game/Combat/EnemyActionManagerTest.cs
+++ b/Assets/Scripts/Test/Editor/Game/Combat/EnemyActionManagerTest.cs
@@ -20,8 +20,8 @@ public class EnemyActionManagerTest
         enemyActionManager = gameObject.AddComponent<EnemyActionManager>();
 
         mockRandomGenerator = new Mock<RandomGenerator>();
-        mockPlayer = new Mock<Player>("name", 100, 1.0f);
-        mockEnemy = new Mock<Enemy>("name", 100, 1.0f);
+        mockPlayer = new Mock<Player>("name", 100, 1);
+        mockEnemy = new Mock<Enemy>("name", 100, 1);
         mockAttack = new Mock<Attack>(null, 5, null, null);
         mockDefend = new Mock<Defend>(null, 5, null, null);
 

--- a/Assets/Scripts/Test/Editor/Game/Combat/StatManagerTest.cs
+++ b/Assets/Scripts/Test/Editor/Game/Combat/StatManagerTest.cs
@@ -26,8 +26,8 @@ public class StatManagerTest
         mockAttack = new Mock<Attack>(null, attackDamage, null, null);
         mockDefend = new Mock<Defend>(null, defendDamageReduction, null, null);
         mockDefend_defenseTooHigh = new Mock<Defend>(null, tooHighDefendDamageReduction, null, null);
-        mockActor = new Mock<Character>("name", 100, 1.0f);
-        mockTarget = new Mock<Character>("name", 100, 1.0f);
+        mockActor = new Mock<Character>("name", 100, 1);
+        mockTarget = new Mock<Character>("name", 100, 1);
         
         mockAttack.Setup(attack => attack.Targets).Returns(new Character[] { mockTarget.Object });
         mockAttack.Setup(attack => attack.Actor).Returns(mockActor.Object);

--- a/Assets/Scripts/Test/Editor/Game/Combat/StatManagerTest.cs
+++ b/Assets/Scripts/Test/Editor/Game/Combat/StatManagerTest.cs
@@ -26,8 +26,8 @@ public class StatManagerTest
         mockAttack = new Mock<Attack>(null, attackDamage, null, null);
         mockDefend = new Mock<Defend>(null, defendDamageReduction, null, null);
         mockDefend_defenseTooHigh = new Mock<Defend>(null, tooHighDefendDamageReduction, null, null);
-        mockActor = new Mock<Character>("name", 100);
-        mockTarget = new Mock<Character>("name", 100);
+        mockActor = new Mock<Character>("name", 100, 1.0f);
+        mockTarget = new Mock<Character>("name", 100, 1.0f);
         
         mockAttack.Setup(attack => attack.Targets).Returns(new Character[] { mockTarget.Object });
         mockAttack.Setup(attack => attack.Actor).Returns(mockActor.Object);

--- a/Assets/Scripts/Test/Editor/Game/Combat/StatManagerTest.cs
+++ b/Assets/Scripts/Test/Editor/Game/Combat/StatManagerTest.cs
@@ -1,4 +1,4 @@
-﻿using UnityEngine;
+using UnityEngine;
 using NUnit.Framework;
 using Moq;
 

--- a/Assets/Scripts/Test/Editor/Game/Combat/TurnManagerTest.cs
+++ b/Assets/Scripts/Test/Editor/Game/Combat/TurnManagerTest.cs
@@ -114,7 +114,10 @@ public class TurnManagerTest
     [Test]
     public void TestShouldWaitForPlayerAction_HasNextAction()
     {
-        actionsQueue.First().Enqueue(mockCharacterAction.Object);
+        Mock<CharacterAction> mockPlayerAction = new Mock<CharacterAction>(null, null, null);
+        mockPlayerAction.Setup(action => action.Actor).Returns(mockPlayer.Object);
+        actionsQueue.First().Enqueue(mockPlayerAction.Object);
+        turnCounts.First()[mockPlayer.Object] = 1;
 
         bool shouldWaitForAction = turnManager.ShouldWaitForPlayerAction(mockPlayer.Object);
 

--- a/Assets/Scripts/Test/Editor/Game/Combat/TurnManagerTest.cs
+++ b/Assets/Scripts/Test/Editor/Game/Combat/TurnManagerTest.cs
@@ -1,4 +1,4 @@
-﻿using UnityEngine;
+using UnityEngine;
 using System.Linq;
 using System.Collections.Generic;
 using NUnit.Framework;
@@ -48,6 +48,20 @@ public class TurnManagerTest
     }
 
     [Test]
+    public void TestRegisterAction_Invalid_CharacterSpeed0()
+    {
+        Mock<CharacterAction> actionWithSpeed0 = new Mock<CharacterAction>(null, null, null);
+        Mock<Character> characterWithSpeed0 = new Mock<Character>("name", 100, 1);
+        actionWithSpeed0.Setup(action => action.Actor).Returns(characterWithSpeed0.Object);
+        characterWithSpeed0.Setup(character => character.Speed).Returns(0);
+
+        Assert.Throws<UnableToRegisterActionException>(delegate()
+        {
+            turnManager.RegisterAction(actionWithSpeed0.Object);
+        });
+    }
+
+    [Test]
     public void TestGetNextAction()
     {
         actionsQueue.First().Enqueue(mockCharacterAction.Object);
@@ -56,6 +70,17 @@ public class TurnManagerTest
 
         Assert.AreEqual(0, actionsQueue.Count);
         Assert.AreSame(mockCharacterAction.Object, action);
+    }
+
+    [Test]
+    public void TestGetNextAction_Invalid_NoActionExists()
+    {
+        actionsQueue.Clear();
+
+        Assert.Throws<NoCharacterActionExistsException>(delegate()
+        {
+            turnManager.GetNextAction();
+        });
     }
 
     [Test]

--- a/Assets/Scripts/Test/Editor/Game/Combat/TurnManagerTest.cs
+++ b/Assets/Scripts/Test/Editor/Game/Combat/TurnManagerTest.cs
@@ -1,25 +1,35 @@
 ﻿using UnityEngine;
+using System.Linq;
 using System.Collections.Generic;
 using NUnit.Framework;
 using Moq;
 
 public class TurnManagerTest
 {
-    Queue<CharacterAction> actionsQueue;
+    List<Queue<CharacterAction>> actionsQueue;
+    List<Dictionary<Character, int>> turnCounts;
     Mock<CharacterAction> mockCharacterAction;
+    Mock<Character> mockCharacter;
+    Mock<Player> mockPlayer;
     GameObject gameObject;
     TurnManager turnManager;
 
     [SetUp]
     public void Setup()
     {
-        actionsQueue = new Queue<CharacterAction>();
+        actionsQueue = new List<Queue<CharacterAction>>();
+        turnCounts = new List<Dictionary<Character, int>>();
         mockCharacterAction = new Mock<CharacterAction>(null, null, null);
+        mockCharacter = new Mock<Character>("name", 100, 1);
+        mockPlayer = givenPlayerWithSpeed(1);
 
         gameObject = new GameObject();
         
         turnManager = gameObject.AddComponent<TurnManager>();
-        turnManager.Init(actionsQueue);
+        turnManager.Init(actionsQueue, turnCounts);
+
+        mockCharacterAction.Setup(action => action.Actor).Returns(mockCharacter.Object);
+        mockCharacter.Setup(character => character.Speed).Returns(1);
     }
 
     [TearDown]
@@ -33,14 +43,14 @@ public class TurnManagerTest
     {
         turnManager.RegisterAction(mockCharacterAction.Object);
 
-        Assert.AreEqual(1, actionsQueue.Count);
-        Assert.AreEqual(mockCharacterAction.Object, actionsQueue.Peek());
+        Assert.AreEqual(1, actionsQueue.First().Count);
+        Assert.AreEqual(mockCharacterAction.Object, actionsQueue.First().Peek());
     }
 
     [Test]
     public void TestGetNextAction()
     {
-        actionsQueue.Enqueue(mockCharacterAction.Object);
+        actionsQueue.First().Enqueue(mockCharacterAction.Object);
 
         CharacterAction action = turnManager.GetNextAction();
 
@@ -49,11 +59,39 @@ public class TurnManagerTest
     }
 
     [Test]
+    public void TestRegisterAction_GetNextAction_DifferentCharacterSpeeds()
+    {
+        Mock<Character> slowCharacter = new Mock<Character>("name", 100, 1);
+        Mock<Character> fastCharacter = new Mock<Character>("name", 100, 1);
+        Mock<CharacterAction> slowCharacterAction = new Mock<CharacterAction>(null, null, null);
+        Mock<CharacterAction> fastCharacterAction = new Mock<CharacterAction>(null, null, null);
+        slowCharacter.Setup(character => character.Speed).Returns(1);
+        fastCharacter.Setup(character => character.Speed).Returns(2);
+        slowCharacterAction.Setup(action => action.Actor).Returns(slowCharacter.Object);
+        fastCharacterAction.Setup(action => action.Actor).Returns(fastCharacter.Object);
+
+        // Register slow character actions first
+        turnManager.RegisterAction(slowCharacterAction.Object);
+        turnManager.RegisterAction(slowCharacterAction.Object);
+        turnManager.RegisterAction(fastCharacterAction.Object);
+        turnManager.RegisterAction(fastCharacterAction.Object);
+
+        // Except the second slow character action to be returned after both fast character actions (based on speed)
+        Assert.AreEqual(2, actionsQueue.Count);
+        Assert.AreEqual(3, actionsQueue.First().Count);
+        Assert.AreSame(slowCharacterAction.Object, turnManager.GetNextAction());
+        Assert.AreSame(fastCharacterAction.Object, turnManager.GetNextAction());
+        Assert.AreSame(fastCharacterAction.Object, turnManager.GetNextAction());
+        Assert.AreSame(slowCharacterAction.Object, turnManager.GetNextAction());
+        Assert.AreEqual(0, actionsQueue.Count);
+    }
+
+    [Test]
     public void TestShouldWaitForPlayerAction_HasNextAction()
     {
-        actionsQueue.Enqueue(mockCharacterAction.Object);
+        actionsQueue.First().Enqueue(mockCharacterAction.Object);
 
-        bool shouldWaitForAction = turnManager.ShouldWaitForPlayerAction();
+        bool shouldWaitForAction = turnManager.ShouldWaitForPlayerAction(mockPlayer.Object);
 
         Assert.False(shouldWaitForAction);
     }
@@ -61,8 +99,25 @@ public class TurnManagerTest
     [Test]
     public void TestShouldWaitForPlayerAction_NoNextAction()
     {
-        bool shouldWaitForAction = turnManager.ShouldWaitForPlayerAction();
+        bool shouldWaitForAction = turnManager.ShouldWaitForPlayerAction(mockPlayer.Object);
 
         Assert.True(shouldWaitForAction);
+    }
+
+    [Test]
+    public void TestShouldWaitForPlayerAction_PlayerSpeed0()
+    {
+        mockPlayer = givenPlayerWithSpeed(0);
+
+        bool shouldWaitForAction = turnManager.ShouldWaitForPlayerAction(mockPlayer.Object);
+
+        Assert.False(shouldWaitForAction);
+    }
+
+    Mock<Player> givenPlayerWithSpeed(int speed)
+    {
+        Mock<Player> mock = new Mock<Player>("name", 100, speed);
+        mock.Setup(player => player.Speed).Returns(speed);
+        return mock;
     }
 }

--- a/Assets/Scripts/Test/Editor/Game/Combat/WeaponTest.cs
+++ b/Assets/Scripts/Test/Editor/Game/Combat/WeaponTest.cs
@@ -1,4 +1,4 @@
-﻿using NUnit.Framework;
+using NUnit.Framework;
 
 public class WeaponTest
 {

--- a/Assets/Scripts/Test/Editor/Util/RandomGeneratorTest.cs
+++ b/Assets/Scripts/Test/Editor/Util/RandomGeneratorTest.cs
@@ -1,4 +1,4 @@
-﻿using NUnit.Framework;
+using NUnit.Framework;
 
 public class RandomGeneratorTest
 {


### PR DESCRIPTION
# Trello 
https://trello.com/c/l9A6CvUk/24-speed-setting-for-characters

# Notes
1. Add concept of rounds to turn manager
1. Characters now have a speed which dictates how many turns they can take per round

# Testing
1. Unit tests
1. Ran through `HelloWorldCombat` scene